### PR TITLE
changes to reload nginx when certificate is renewed.

### DIFF
--- a/ansible/nginx.yml
+++ b/ansible/nginx.yml
@@ -70,4 +70,4 @@
       cron:
         name: letsencrypt_renewal
         special_time: daily
-        job: letsencrypt renew --post-hook "service nginx reload"
+        job: letsencrypt renew --post-hook "/usr/sbin/service nginx reload"


### PR DESCRIPTION
This should fix the issue of not getting the new certificate.

At least the manual changes to zapd appears to have renewed the certificate.